### PR TITLE
create history-pages

### DIFF
--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -1312,3 +1312,239 @@ html, body {
   line-height: 1;
   font-variation-settings: "FILL" 0, "wght" 600, "GRAD" 0, "opsz" 24;
 }
+/* ===============================
+   History (一覧)
+=============================== */
+
+.history-list{
+  padding: 18px 22px 20px;
+  display: grid;
+  gap: 14px;
+  overflow-y: auto;
+}
+
+/* 空状態 */
+.history-empty{
+  padding: 40px 22px 34px;
+  text-align: center;
+  display: grid;
+  gap: 12px;
+}
+
+.history-empty-icon{
+  width: 84px;
+  height: 84px;
+  margin: 10px auto 6px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.04);
+  display: grid;
+  place-items: center;
+}
+
+.history-empty-icon .material-symbols-rounded{
+  font-size: 38px;
+  color: rgba(15, 23, 42, 0.35);
+}
+
+.history-empty-title{
+  margin: 0;
+  font-size: 18px;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.history-empty-sub{
+  margin: 0 auto;
+  max-width: 28ch;
+  font-size: 13px;
+  line-height: 1.7;
+  color: #64748b;
+}
+
+.history-empty-btn{
+  margin-top: 12px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  height: 52px;
+  padding: 0 18px;
+  border-radius: 18px;
+  background: var(--primary); /* #CC9A06 */
+  color: #fff;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-decoration: none;
+  box-shadow: 0 12px 18px rgba(15,23,42,0.14);
+}
+
+.history-empty-btn:hover{ background: var(--primary-hover); }
+
+/* 編集ボタン */
+.history-actions{
+  margin-top: 10px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.history-edit-btn{
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 36px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.10);
+  background: rgba(15, 23, 42, 0.02);
+  color: #0f172a;
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.history-edit-btn .material-symbols-rounded{ font-size: 18px; }
+.history-edit-btn:hover{ background: rgba(15, 23, 42, 0.04); }
+.review-menu-row{
+  display: flex;
+  justify-content: center;
+  padding: 10px 0 12px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06); /* うっすら区切り */
+}
+
+.review-menu-btn{
+  height: 40px;
+  padding: 0 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+
+  background: var(--btn); /* 緑（ログインと同じ） */
+  color: #fff;
+
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+
+  box-shadow: 0 10px 18px rgba(15,23,42,0.12);
+  cursor: pointer;
+}
+
+.review-menu-btn:active{ transform: translateY(1px); }
+/* ===== History actions ===== */
+.history-actions{
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+/* 編集ボタン（既存があるなら不要。なければこれで整う） */
+.history-edit-btn{
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 36px;
+  padding: 0 12px;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 13px;
+
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+  box-shadow: 0 10px 16px rgba(15,23,42,0.06);
+}
+
+.history-edit-btn .material-symbols-rounded{
+  font-size: 18px;
+}
+
+/* 削除アイコン（“削除感”は出すが、過度に危険っぽくしない） */
+.history-delete-btn{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  color: #b91c1c; /* うっすら赤＝削除イメージ */
+  box-shadow: 0 10px 16px rgba(15,23,42,0.06);
+
+  cursor: pointer;
+}
+
+.history-delete-btn .material-symbols-rounded{
+  font-size: 20px;
+}
+
+.history-delete-btn:hover{
+  filter: brightness(0.98);
+}
+
+.history-delete-btn:active{
+  transform: translateY(1px);
+}
+
+.history-delete-btn:focus-visible{
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(185,28,28,0.18), 0 10px 16px rgba(15,23,42,0.06);
+}
+.frame-title{
+  margin: 0;
+  padding: 8px 22px 0;  /* review-create-main と揃える */
+  font-size: 16px;
+  font-weight: 800;
+  color: #0f172a;
+  letter-spacing: 0.04em;
+}
+.frame-title--center{
+  text-align: center;
+  margin: 10px 0 14px;
+}
+/* 店舗名（表示だけ）を控えめなラベル感に */
+.store-display{
+  user-select: none;
+  cursor: default;
+  margin-bottom: 8px;
+
+  /* 色だけ薄くする（フォント/サイズは review-label のまま） */
+  opacity: 0.65;
+}
+.frame-title-center{
+  text-align: center;
+  margin: 18px 0 10px;
+}
+/* ===== Frame title (histories / edit etc.) ===== */
+.frame-title{
+  margin: 10px 0 6px;
+  font-size: 22px;     /* ← create の store 見出し(22px)と同格 */
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  color: var(--text);
+}
+
+/* 中央寄せ用（あなたが使ってる想定） */
+.frame-title-center{
+  text-align: center;
+}
+/* 履歴カード：店舗名表示 */
+.history-store{
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.history-store-label{
+  font-size: 11px;
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.45); /* うすめ */
+  letter-spacing: 0.08em;
+}
+
+.history-store-name{
+  font-size: 14px;
+  font-weight: 800;
+  color: rgba(15, 23, 42, 0.82); /* 主張しすぎない濃さ */
+}

--- a/resources/views/components/histories/frame.blade.php
+++ b/resources/views/components/histories/frame.blade.php
@@ -1,0 +1,17 @@
+@props([
+  'store' => '',
+  'account' => '',
+  'title' => null,
+  'hideStore' => false,
+])
+
+<x-review-frame
+  :store="$store"
+  :account="$account"
+  active="history"
+  nav="menu"
+  :title="$title"
+  :hide-store="$hideStore"
+>
+  {{ $slot }}
+</x-review-frame>

--- a/resources/views/components/review-frame.blade.php
+++ b/resources/views/components/review-frame.blade.php
@@ -1,43 +1,34 @@
 @props([
-  'store' => 'なんばスカイオ店',
-  'account' => 'Account No.0001',
-  'active' => 'index', // index | create
+  'store' => '',
+  'account' => '',
+  'active' => null,
+  'nav' => 'menu',
+  'title' => null,
 ])
 
 <div class="review-create-page">
   <div class="review-create-card">
-
-    {{-- ===== header (createと完全共通) ===== --}}
     <header class="review-create-header">
       <div class="review-create-header-row">
         <span class="review-create-brand">まだある？ナビ</span>
         <span class="review-create-account">{{ $account }}</span>
       </div>
 
-      <h1 class="review-create-store">{{ $store }}</h1>
+      {{-- ✅ メインタイトル（中央） --}}
+      @if($title)
+        <h1 class="frame-title frame-title--center">{{ $title }}</h1>
+      @endif
 
-      <div class="review-create-tabs">
-        <a href="/review" class="tab-item {{ $active === 'index' ? 'is-active' : '' }}">
-          <span class="material-symbols-rounded tab-icon">list_alt</span>
-          <span class="tab-label">口コミ一覧</span>
-        </a>
+      {{-- ✅ 店舗名はサブにする --}}
+      <p class="review-create-store">{{ $store }}</p>
 
-        <a href="/create" class="tab-item {{ $active === 'create' ? 'is-active' : '' }}">
-          <span class="material-symbols-rounded tab-icon">edit_note</span>
-          <span class="tab-label">投稿する</span>
-        </a>
-
-        <button type="button" class="tab-item" onclick="history.back()">
-          <span class="material-symbols-rounded tab-icon">arrow_back</span>
-          <span class="tab-label">戻る</span>
-        </button>
-      </div>
+      @if($nav === 'menu')
+        <div class="review-menu-row">
+          <button type="button" class="review-menu-btn">MENU</button>
+        </div>
+      @endif
     </header>
 
-    {{-- ===== body slot ===== --}}
-    <div class="review-frame-body">
-      {{ $slot }}
-    </div>
-
+    {{ $slot }}
   </div>
 </div>

--- a/resources/views/histories/edit.blade.php
+++ b/resources/views/histories/edit.blade.php
@@ -1,0 +1,69 @@
+@php
+  // UI確認用（あとで controller から $review が来る想定）
+  $review = $review ?? (object)[
+    'product_name' => 'ほうじ茶フラペチーノ',
+    'status' => 'available',
+    'comment' => "甘さ控えめ。スッキリ飲めて最高！\nホイップ増量＆ブラウンシュガートッピングが\nおすすめです♪",
+  ];
+@endphp
+
+<x-app-layout>
+  <x-histories.frame
+    store="なんばスカイオ店"
+    account="Account No.0001"
+    title="口コミ編集"
+    :hide-store="true"
+  >
+    <form action="#" method="POST" class="review-create-form">
+      @csrf
+      {{-- 本当は edit なら PUT/PATCH にする（UI確認なら不要でもOK） --}}
+      {{-- @method('PATCH') --}}
+
+      {{-- 以下は投稿履歴で選択した口コミの編集フォームを表示 --}}
+      <main class="review-create-main">
+        <div class="review-field">
+          {{-- ✅ 店舗名（表示のみ） --}}
+          <div class="review-label store-display" aria-hidden="true">
+            {{ $store ?? 'なんばスカイオ店' }}
+          </div>
+
+          <label class="review-label" for="product">商品名</label>
+          <input
+            id="product"
+            type="text"
+            name="product"
+            class="review-input"
+            value="{{ old('product', $review->product_name) }}"
+          >
+        </div>
+        <div class="review-field">
+          <label class="review-label" for="status">販売状況</label>
+
+          <div class="review-select-wrap">
+            <select id="status" name="status" class="review-select">
+              <option value="available" @selected(old('status', $review->status) === 'available')>まだある</option>
+              <option value="soldout" @selected(old('status', $review->status) === 'soldout')>もうない</option>
+            </select>
+            <span class="review-select-caret" aria-hidden="true"></span>
+          </div>
+        </div>
+
+        <div class="review-field">
+          <label class="review-label" for="message">メッセージ</label>
+          <textarea
+            id="message"
+            name="message"
+            rows="6"
+            class="review-textarea"
+          >{{ old('message', $review->comment) }}</textarea>
+        </div>
+      </main>
+
+      <footer class="review-submit">
+        <button type="submit" class="review-submit-btn">
+          <span class="review-submit-label">更新する</span>
+        </button>
+      </footer>
+    </form>
+  </x-histories.frame>
+</x-app-layout>

--- a/resources/views/histories/index-empty.blade.php
+++ b/resources/views/histories/index-empty.blade.php
@@ -1,0 +1,20 @@
+<x-app-layout>
+  <x-review-frame
+    account="Account No.0001"
+    active="history"
+    nav="menu"
+    title="投稿履歴"
+  >
+    {{-- main --}}
+    <main class="history-empty">
+      <div class="history-empty-icon" aria-hidden="true">
+        <span class="material-symbols-rounded">history</span>
+      </div>
+
+      <p class="history-empty-title">履歴がまだありません</p>
+      <p class="history-empty-sub">
+        店舗の在庫状況を投稿すると、ここに履歴として残ります。
+      </p>
+    </main>
+  </x-review-frame>
+</x-app-layout>

--- a/resources/views/histories/index.blade.php
+++ b/resources/views/histories/index.blade.php
@@ -1,0 +1,64 @@
+@php
+  // UI確認用ダミーデータ（あとでコントローラから渡す想定）
+  $histories = $histories ?? collect([
+    (object)[
+      'store_name'   => 'なんばスカイオ店',
+      'status'       => 'available',
+      'product_name' => 'ほうじ茶フラペチーノ',
+      'comment'      => '甘さ控えめ。スッキリ飲めて最高！',
+      'created_at'   => '2026/01/21 20:55'
+    ],
+    (object)[
+      'store_name'   => '梅田ルクア店',
+      'status'       => 'soldout',
+      'product_name' => '抹茶ラテ',
+      'comment'      => '夕方にはもう無かったです…',
+      'created_at'   => '2026/01/21 18:48'
+    ],
+  ]);
+@endphp
+
+<x-app-layout>
+  <x-review-frame
+    account="Account No.0001"
+    active="history"
+    nav="menu"
+    title="投稿履歴"
+  >
+    <main class="history-list">
+      @foreach ($histories as $h)
+        <article class="review-index-card history-card">
+          <div class="review-index-card-head">
+            {{-- ✅ 左：店舗名だけ表示（ユーザー名・アイコンは無し） --}}
+            <div class="history-store">
+              <span class="history-store-name">{{ $h->store_name }}</span>
+            </div>
+
+            {{-- 右：日時 --}}
+            <time class="review-index-time">{{ $h->created_at }}</time>
+          </div>
+
+          @if ($h->status === 'available')
+            <div class="review-index-status is-available">販売状況：まだある</div>
+          @else
+            <div class="review-index-status is-soldout">販売状況：もうない</div>
+          @endif
+
+          <div class="review-index-product">商品名：{{ $h->product_name }}</div>
+          <p class="review-index-comment">{{ $h->comment }}</p>
+
+          <div class="history-actions">
+            <a class="history-edit-btn" href="{{ url('/history-edit') }}">
+              <span class="material-symbols-rounded">edit</span>
+              編集する
+            </a>
+
+            <button type="button" class="history-delete-btn" aria-label="削除">
+              <span class="material-symbols-rounded">delete</span>
+            </button>
+          </div>
+        </article>
+      @endforeach
+    </main>
+  </x-review-frame>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -124,8 +124,14 @@ Route::get('/review', function () {
 
 //口コミ投稿-create画面確認用 http://127.0.0.1:8000/create---
 Route::view('/create', 'reviews.create');
-//-----------------------------
-// Route::view('/register', 'register');
+// 履歴一覧（0件表示用）http://127.0.0.1:8000/history-empty---
+Route::view('/history-empty', 'histories.index-empty');
+
+// 履歴一覧（ダミー表示用）http://127.0.0.1:8000/history---
+Route::view('/history', 'histories.index');
+
+// 履歴編集（UI確認用）http://127.0.0.1:8000/history-edit---
+Route::view('/history-edit', 'histories.edit');
 
 // これは最後
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
histories/index.blade.php：投稿履歴の表示を「ユーザー名→店舗名」に変更
共通フレーム（x-review-frame）に統一

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a History section to view, edit, and delete posting history entries.
  * Introduced an empty state display when no history exists.
  * Included visual styling and layout for the history management interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->